### PR TITLE
Update FMX.Player.pas

### DIFF
--- a/Sources/FMX.Player.pas
+++ b/Sources/FMX.Player.pas
@@ -181,6 +181,7 @@ var
 implementation
 
 uses
+  FMX.Platform,
   {$IFDEF MSWINDOWS}
   Winapi.Windows,
   {$ENDIF}


### PR DESCRIPTION
[DCC Error] FMX.Player.pas(621): E2003 Undeclared identifier: 'TPlatformServices'